### PR TITLE
Implement a find/replace for sitemap URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,13 @@ Usage: pa11y-ci [options]
 
 Options:
 
-  -h, --help           output usage information
-  -V, --version        output the version number
-  -c, --config <path>  the path to a JSON or JavaScript config file
-  -s, --sitemap <url>  the path to a sitemap
-  -j, --json           Output results as JSON
+  -h, --help                      output usage information
+  -V, --version                   output the version number
+  -c, --config <path>             the path to a JSON or JavaScript config file
+  -s, --sitemap <url>             the path to a sitemap
+  -f, --sitemap-find <pattern>    a pattern to find in sitemaps. Use with --sitemap-replace
+  -r, --sitemap-replace <string>  a replacement to apply in sitemaps. Use with --sitemap-find
+  -j, --json                      Output results as JSON
 ```
 
 ### Configuration
@@ -111,6 +113,14 @@ pa11y-ci --sitemap http://pa11y.org/sitemap.xml
 ```
 
 This takes the text content of each `<loc>` in the XML and runs Pa11y against that URL. This can also be combined with a config file, but URLs in the Sitemap will override any found in your JSON config.
+
+If you'd like to perform a find/replace operation on each URL in a sitemap, e.g. if your sitemap points to your production URLs rather than local ones, then you can use the following flags:
+
+```sh
+pa11y-ci --sitemap http://pa11y.org/sitemap.xml --sitemap-find pa11y.org --sitemap-replace localhost
+```
+
+The above would ensure that you run Pa11y CI against local URLs instead of the live site.
 
 
 ## Contributing

--- a/bin/pa11y-ci.js
+++ b/bin/pa11y-ci.js
@@ -29,6 +29,14 @@ program
 		'the path to a sitemap'
 	)
 	.option(
+		'-f, --sitemap-find <pattern>',
+		'a pattern to find in sitemaps. Use with --sitemap-replace'
+	)
+	.option(
+		'-r, --sitemap-replace <string>',
+		'a replacement to apply in sitemaps. Use with --sitemap-find'
+	)
+	.option(
 		'-j, --json',
 		'Output results as JSON'
 	)
@@ -43,7 +51,7 @@ Promise.resolve()
 	.then(config => {
 		// Load a sitemap based on the `--sitemap` flag
 		if (program.sitemap) {
-			return loadSitemapIntoConfig(program.sitemap, config);
+			return loadSitemapIntoConfig(program, config);
 		}
 		return config;
 	})
@@ -148,7 +156,11 @@ function defaultConfig(config) {
 
 // Load a sitemap from a remote URL, parse out the
 // URLs, and add them to an existing config object
-function loadSitemapIntoConfig(sitemapUrl, config) {
+function loadSitemapIntoConfig(program, config) {
+	const sitemapUrl = program.sitemap;
+	const sitemapFind = (program.sitemapFind ? new RegExp(program.sitemapFind, 'gi') : null);
+	const sitemapReplace = program.sitemapReplace || '';
+
 	return Promise.resolve()
 		.then(() => {
 			return fetch(sitemapUrl);
@@ -161,7 +173,11 @@ function loadSitemapIntoConfig(sitemapUrl, config) {
 				xmlMode: true
 			});
 			config.urls = $('url > loc').toArray().map(element => {
-				return $(element).text();
+				let url = $(element).text();
+				if (sitemapFind) {
+					url = url.replace(sitemapFind, sitemapReplace);
+				}
+				return url;
 			});
 			return config;
 		})

--- a/test/integration/cli-sitemap.js
+++ b/test/integration/cli-sitemap.js
@@ -42,3 +42,25 @@ describe('pa11y-ci (with a sitemap that can\'t be loaded)', () => {
 	});
 
 });
+
+describe('pa11y-ci (with a sitemap and find/replace)', () => {
+
+	before(() => {
+		return global.cliCall([
+			'--sitemap',
+			'http://localhost:8090/sitemap.xml',
+			'--sitemap-find',
+			'LOCALHOST',
+			'--sitemap-replace',
+			'127.0.0.1',
+			'--config',
+			'empty'
+		]);
+	});
+
+	it('loads the expected sitemap and performs a find/replace on the URLs', () => {
+		assert.include(global.lastResult.output, 'http://127.0.0.1:8090/passing-1');
+		assert.include(global.lastResult.output, 'http://127.0.0.1:8090/failing-1');
+	});
+
+});


### PR DESCRIPTION
Allow a user to find/replace within sitemap URLs before running Pa11y
tests. Resolves #2.

Sometimes (e.g. with Jekyll) a locally generated sitemap for your site
will include the production URLs. If you want to run Pa11y against a
local copy of the site then you need to find/replace in these URLs.