### PR TITLE
Add command line option: sitemap-exclude

### DIFF
--- a/test/integration/cli-sitemap.js
+++ b/test/integration/cli-sitemap.js
@@ -17,6 +17,7 @@ describe('pa11y-ci (with a sitemap)', () => {
 	it('loads the expected sitemap', () => {
 		assert.include(global.lastResult.output, 'http://localhost:8090/passing-1');
 		assert.include(global.lastResult.output, 'http://localhost:8090/failing-1');
+		assert.include(global.lastResult.output, 'http://localhost:8090/excluded');
 	});
 
 });
@@ -61,6 +62,28 @@ describe('pa11y-ci (with a sitemap and find/replace)', () => {
 	it('loads the expected sitemap and performs a find/replace on the URLs', () => {
 		assert.include(global.lastResult.output, 'http://127.0.0.1:8090/passing-1');
 		assert.include(global.lastResult.output, 'http://127.0.0.1:8090/failing-1');
+		assert.include(global.lastResult.output, 'http://127.0.0.1:8090/excluded');
+	});
+
+});
+
+describe('pa11y-ci (with a sitemap and sitemap-exclude)', () => {
+
+	before(() => {
+		return global.cliCall([
+			'--sitemap',
+			'http://localhost:8090/sitemap.xml',
+			'--sitemap-exclude',
+			'EXCLUDED',
+			'--config',
+			'empty'
+		]);
+	});
+
+	it('loads the expected sitemap without the excluded URLs', () => {
+		assert.include(global.lastResult.output, 'http://localhost:8090/passing-1');
+		assert.include(global.lastResult.output, 'http://localhost:8090/failing-1');
+		assert.doesNotInclude(global.lastResult.output, 'http://localhost:8090/excluded');
 	});
 
 });

--- a/test/integration/mock/website/html/excluded.html
+++ b/test/integration/mock/website/html/excluded.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="utf-8"/>
+	<title>Page Title</title>
+</head>
+<body>
+	<h1>Hello World</h1>
+</body>
+</html>

--- a/test/integration/mock/website/sitemap.xml
+++ b/test/integration/mock/website/sitemap.xml
@@ -6,4 +6,7 @@
 	<url>
 		<loc>http://localhost:8090/failing-1</loc>
 	</url>
+	<url>
+		<loc>http://localhost:8090/excluded</loc>
+	</url>
 </urlset>


### PR DESCRIPTION
This should allow for simpler use of existing sitemaps rather than requiring pa11y-specific ones; https://github.com/pa11y/ci/issues/10